### PR TITLE
Add RMT LED support

### DIFF
--- a/esp32m/CMakeLists.txt
+++ b/esp32m/CMakeLists.txt
@@ -3,7 +3,7 @@ set(CMAKE_CXX_STANDARD 20)
 idf_component_register(
     SRC_DIRS "src" "src/events" "src/log" "src/config" "src/bus" "src/net" "src/fs" "src/io" "src/bt" "src/ui" "src/dev" "src/dev/opentherm" "src/debug" "src/integrations/ha" "src/integrations/influx"
     INCLUDE_DIRS "include"
-    REQUIRES esp_common nvs_flash bootloader_support app_update spiffs esp_http_client esp_https_ota esp_http_server console esp_wifi esp_adc mqtt spi_flash driver bt wpa_supplicant esp_eth espressif__led_strip
+    REQUIRES esp_common nvs_flash bootloader_support app_update spiffs esp_http_client esp_https_ota esp_http_server console esp_wifi esp_adc mqtt spi_flash driver bt wpa_supplicant esp_eth
 )
 
 set(web_ui_build_dir "${CMAKE_BINARY_DIR}/web-ui")

--- a/esp32m/CMakeLists.txt
+++ b/esp32m/CMakeLists.txt
@@ -3,7 +3,7 @@ set(CMAKE_CXX_STANDARD 20)
 idf_component_register(
     SRC_DIRS "src" "src/events" "src/log" "src/config" "src/bus" "src/net" "src/fs" "src/io" "src/bt" "src/ui" "src/dev" "src/dev/opentherm" "src/debug" "src/integrations/ha" "src/integrations/influx"
     INCLUDE_DIRS "include"
-    REQUIRES esp_common nvs_flash bootloader_support app_update spiffs esp_http_client esp_https_ota esp_http_server console esp_wifi esp_adc mqtt spi_flash driver bt wpa_supplicant esp_eth
+    REQUIRES esp_common nvs_flash bootloader_support app_update spiffs esp_http_client esp_https_ota esp_http_server console esp_wifi esp_adc mqtt spi_flash driver bt wpa_supplicant esp_eth espressif__led_strip
 )
 
 set(web_ui_build_dir "${CMAKE_BINARY_DIR}/web-ui")

--- a/esp32m/idf_component.yml
+++ b/esp32m/idf_component.yml
@@ -12,3 +12,4 @@ dependencies:
   bblanchon/arduinojson:
     public: true
     version: "^6.21.2"
+  espressif/led_strip: "^2.5.2"

--- a/esp32m/idf_component.yml
+++ b/esp32m/idf_component.yml
@@ -12,4 +12,6 @@ dependencies:
   bblanchon/arduinojson:
     public: true
     version: "^6.21.2"
-  espressif/led_strip: "^2.5.2"
+  espressif/led_strip: 
+    public: true
+    version: "^2.5.2"

--- a/esp32m/include/esp32m/dev/rmtled.hpp
+++ b/esp32m/include/esp32m/dev/rmtled.hpp
@@ -11,7 +11,7 @@
 
 namespace esp32m {
   namespace dev {
-    class Rmtled {
+    class Rmtled : public log::SimpleLoggable {
      public:
       Rmtled(gpio_num_t pin);
       Rmtled(const Rmtled &) = delete;

--- a/esp32m/include/esp32m/dev/rmtled.hpp
+++ b/esp32m/include/esp32m/dev/rmtled.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "esp32m/device.hpp"
+#include "esp32m/events/request.hpp"
 #include "esp32m/io/pins.hpp"
 
 #include <freertos/FreeRTOS.h>
@@ -11,10 +13,16 @@
 
 namespace esp32m {
   namespace dev {
-    class Rmtled : public log::SimpleLoggable {
+
+    class Rmtled : public Device {
      public:
       Rmtled(gpio_num_t pin);
       Rmtled(const Rmtled &) = delete;
+      const char *name() const override {
+        return "rmtled";
+      }
+     protected:
+      bool handleRequest(Request &req) override; 
 
      private:
       gpio_num_t _pin;
@@ -23,9 +31,10 @@ namespace esp32m {
       void configure_led();
       void init();
       void run();
-      void toggle_led();
       void blink(int count);
     };
+
     Rmtled *useRmtled(gpio_num_t pin);
+
   }  // namespace dev
 }  // namespace esp32m

--- a/esp32m/include/esp32m/dev/rmtled.hpp
+++ b/esp32m/include/esp32m/dev/rmtled.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "esp32m/io/pins.hpp"
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+
+#include "esp32m/defs.hpp"
+
+#include "led_strip.h"
+
+namespace esp32m {
+  namespace dev {
+    class Rmtled {
+     public:
+      Rmtled(gpio_num_t pin);
+      Rmtled(const Rmtled &) = delete;
+
+     private:
+      gpio_num_t _pin;
+      TaskHandle_t _task = nullptr;
+      led_strip_handle_t led_strip;
+      void configure_led();
+      void init();
+      void run();
+      void toggle_led();
+      void blink(int count);
+    };
+    Rmtled *useRmtled(gpio_num_t pin);
+  }  // namespace dev
+}  // namespace esp32m

--- a/esp32m/src/dev/rmtled.cpp
+++ b/esp32m/src/dev/rmtled.cpp
@@ -11,7 +11,7 @@
 // 10MHz resolution, 1 tick = 0.1us (led strip needs a high resolution)
 #define LED_STRIP_RMT_RES_HZ  (10 * 1000 * 1000)
 
-uint32_t led_color[3] = { 50, 50, 50 };  // Red, Green, Blue  (0-255) 
+uint32_t led_color[3] = { 16, 0, 16 };  // Red, Green, Blue  (0-255) 
 
 
 namespace esp32m {

--- a/esp32m/src/dev/rmtled.cpp
+++ b/esp32m/src/dev/rmtled.cpp
@@ -1,0 +1,108 @@
+#include "esp32m/dev/rmtled.hpp"
+#include "esp32m/base.hpp"
+#include "esp32m/debug/diag.hpp"
+#include "esp32m/io/gpio.hpp"
+#include <esp_task_wdt.h>
+#include "led_strip.h"
+#include "esp_log.h"
+#include "esp_err.h"
+
+static const char *TAG = "RMTLED";
+
+
+// 10MHz resolution, 1 tick = 0.1us (led strip needs a high resolution)
+#define LED_STRIP_RMT_RES_HZ  (10 * 1000 * 1000)
+
+
+static uint8_t s_led_state = 0;
+
+namespace esp32m {
+  namespace dev {
+    Rmtled::Rmtled(gpio_num_t pin) {
+      _pin=pin;
+      init();
+    }
+
+
+    void Rmtled::configure_led() {
+      ESP_LOGI(TAG, "Initialising addressable LED");
+      /* LED strip initialization with the GPIO and pixels number*/
+      led_strip_config_t strip_config = {
+        .strip_gpio_num = _pin,                   // The GPIO that connected to the LED strip's data line
+        .max_leds = 1,                            // The number of LEDs in the strip,
+        .led_pixel_format = LED_PIXEL_FORMAT_GRB, // Pixel format of your LED strip
+        .led_model = LED_MODEL_WS2812,            // LED strip model
+        .flags = { 
+            .invert_out = false,                  // whether to invert the output signal
+          }
+      };
+
+     // LED strip backend configuration: RMT
+      led_strip_rmt_config_t rmt_config = {
+          .clk_src = RMT_CLK_SRC_DEFAULT,         // different clock source can lead to different power consumption
+          .resolution_hz = LED_STRIP_RMT_RES_HZ,  // RMT counter clock frequency
+          .mem_block_symbols=64,
+          .flags = {
+              .with_dma = false,                  // DMA feature is available on ESP target like ESP32-S3
+            }
+      };
+      
+      ESP_ERROR_CHECK(led_strip_new_rmt_device(&strip_config, &rmt_config, &led_strip));
+      ESP_LOGI(TAG, "Created LED strip object with RMT backend");
+
+    }
+
+
+    void Rmtled::init() {
+      configure_led();
+      xTaskCreate([](void *self) { ((Rmtled *)self)->run(); }, "m/rmtled", 2048,
+                  this, tskIDLE_PRIORITY + 1, &_task);
+    }
+
+    void Rmtled::toggle_led()
+      {
+          /* If the addressable LED is enabled */
+          if (s_led_state) {
+              /* Set the LED pixel using RGB from 0 (0%) to 255 (100%) for each color */
+              led_strip_set_pixel(led_strip, 0, 0, 24, 48);
+              /* Refresh the strip to send data */
+              led_strip_refresh(led_strip);
+          } else {
+              /* Set all LED off to clear all pixels */
+              led_strip_clear(led_strip);
+          }
+          s_led_state = !s_led_state;
+      }
+
+
+    void Rmtled::blink(int count) {
+
+        for (int i = 0; i < count; i++) {
+          toggle_led();
+          delay(200);
+          toggle_led();
+          delay(100);
+        }
+      
+    }
+
+
+    void Rmtled::run() {
+      esp_task_wdt_add(NULL);
+      for (;;) {
+        esp_task_wdt_reset();
+        for (int i = 0; i < 11; i++) {
+          blink(i);
+          delay(750);
+        }
+        delay(2000);
+      }
+    }
+
+
+    Rmtled *useRmtled(gpio_num_t pin) {
+      return new Rmtled(pin);
+    }
+
+  }  // namespace debug
+}  // namespace esp32m

--- a/esp32m/src/dev/rmtled.cpp
+++ b/esp32m/src/dev/rmtled.cpp
@@ -7,25 +7,22 @@
 #include "esp_log.h"
 #include "esp_err.h"
 
-static const char *TAG = "RMTLED";
-
 
 // 10MHz resolution, 1 tick = 0.1us (led strip needs a high resolution)
 #define LED_STRIP_RMT_RES_HZ  (10 * 1000 * 1000)
-
 
 static uint8_t s_led_state = 0;
 
 namespace esp32m {
   namespace dev {
-    Rmtled::Rmtled(gpio_num_t pin) {
+    Rmtled::Rmtled(gpio_num_t pin) 
+      : SimpleLoggable("rmtled") {
       _pin=pin;
       init();
     }
 
-
     void Rmtled::configure_led() {
-      ESP_LOGI(TAG, "Initialising addressable LED");
+      logI( "Initialising addressable LED");
       /* LED strip initialization with the GPIO and pixels number*/
       led_strip_config_t strip_config = {
         .strip_gpio_num = _pin,                   // The GPIO that connected to the LED strip's data line
@@ -48,10 +45,8 @@ namespace esp32m {
       };
       
       ESP_ERROR_CHECK(led_strip_new_rmt_device(&strip_config, &rmt_config, &led_strip));
-      ESP_LOGI(TAG, "Created LED strip object with RMT backend");
-
+      logI("Created LED strip object with RMT backend");
     }
-
 
     void Rmtled::init() {
       configure_led();
@@ -59,46 +54,42 @@ namespace esp32m {
                   this, tskIDLE_PRIORITY + 1, &_task);
     }
 
-    void Rmtled::toggle_led()
-      {
-          /* If the addressable LED is enabled */
-          if (s_led_state) {
-              /* Set the LED pixel using RGB from 0 (0%) to 255 (100%) for each color */
-              led_strip_set_pixel(led_strip, 0, 0, 24, 48);
-              /* Refresh the strip to send data */
-              led_strip_refresh(led_strip);
-          } else {
-              /* Set all LED off to clear all pixels */
-              led_strip_clear(led_strip);
-          }
-          s_led_state = !s_led_state;
+    void Rmtled::toggle_led() {
+      /* If the addressable LED is enabled */
+      if (s_led_state) {
+          /* Set the LED pixel using RGB from 0 (0%) to 255 (100%) for each color */
+          led_strip_set_pixel(led_strip, 0, 0, 0, 48);
+          /* Refresh the strip to send data */
+          led_strip_refresh(led_strip);
+      } else {
+          /* Set all LED off to clear all pixels */
+          led_strip_clear(led_strip);
       }
-
-
-    void Rmtled::blink(int count) {
-
-        for (int i = 0; i < count; i++) {
-          toggle_led();
-          delay(200);
-          toggle_led();
-          delay(100);
-        }
-      
+      s_led_state = !s_led_state;
     }
 
+    void Rmtled::blink(int count) {
+      for (int i = 0; i < count; i++) {
+        toggle_led();
+        delay(200);
+        toggle_led();
+        delay(200);
+      }
+    }
 
     void Rmtled::run() {
+      uint8_t codes[10];
       esp_task_wdt_add(NULL);
       for (;;) {
         esp_task_wdt_reset();
-        for (int i = 0; i < 11; i++) {
-          blink(i);
-          delay(750);
+        auto c = debug::Diag::instance().toArray(codes, sizeof(codes));
+        for (int i = 0; i < c; i++) {
+          blink(codes[i]);
+          delay(1000);
         }
-        delay(2000);
+        delay(1000);
       }
     }
-
 
     Rmtled *useRmtled(gpio_num_t pin) {
       return new Rmtled(pin);


### PR DESCRIPTION
This PR adds support for an addressable LED eg as fitted to the ESP Devkit-M

It displays diag codes , eg blink twice during wifi connect, blink once when connected

It uses the  espressif/led_strip: "^2.5.2" managed component

The color/brightness can be changed by issuing a command like 

`{"type":"request","target":"rmtled","name":"color","data": [0,128,0]}`

to set the LED to green with half brightness

To enable it,  pass the desired pin to the constructor in main eg

`  dev::useRmtled(GPIO_NUM_48);`

