### PR TITLE
Select _uart_config according to menuconfig setting.

### DIFF
--- a/esp32m/include/esp32m/ui/console.hpp
+++ b/esp32m/include/esp32m/ui/console.hpp
@@ -21,7 +21,13 @@ namespace esp32m {
       Console();
       esp_console_repl_t* _repl;
       esp_console_repl_config_t _repl_config;
-      esp_console_dev_uart_config_t _uart_config;
+      #if defined(CONFIG_ESP_CONSOLE_UART_DEFAULT) || defined(CONFIG_ESP_CONSOLE_UART_CUSTOM)
+          esp_console_dev_uart_config_t _uart_config = ESP_CONSOLE_DEV_UART_CONFIG_DEFAULT();
+      #elif defined(CONFIG_ESP_CONSOLE_USB_CDC)
+          esp_console_dev_usb_cdc_config_t _uart_config = ESP_CONSOLE_DEV_CDC_CONFIG_DEFAULT();
+      #elif defined(CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG)
+          esp_console_dev_usb_serial_jtag_config_t _uart_config = ESP_CONSOLE_DEV_USB_SERIAL_JTAG_CONFIG_DEFAULT();
+      #endif
       friend int requestHandler(int argc, char** argv);
     };
 

--- a/esp32m/include/esp32m/ui/console.hpp
+++ b/esp32m/include/esp32m/ui/console.hpp
@@ -21,13 +21,6 @@ namespace esp32m {
       Console();
       esp_console_repl_t* _repl;
       esp_console_repl_config_t _repl_config;
-      #if defined(CONFIG_ESP_CONSOLE_UART_DEFAULT) || defined(CONFIG_ESP_CONSOLE_UART_CUSTOM)
-          esp_console_dev_uart_config_t _uart_config = ESP_CONSOLE_DEV_UART_CONFIG_DEFAULT();
-      #elif defined(CONFIG_ESP_CONSOLE_USB_CDC)
-          esp_console_dev_usb_cdc_config_t _uart_config = ESP_CONSOLE_DEV_CDC_CONFIG_DEFAULT();
-      #elif defined(CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG)
-          esp_console_dev_usb_serial_jtag_config_t _uart_config = ESP_CONSOLE_DEV_USB_SERIAL_JTAG_CONFIG_DEFAULT();
-      #endif
       friend int requestHandler(int argc, char** argv);
     };
 

--- a/esp32m/src/ui/console.cpp
+++ b/esp32m/src/ui/console.cpp
@@ -6,20 +6,13 @@
 
 namespace esp32m {
   namespace ui {
+
     Console::Console() {
       _repl = nullptr;
       _repl_config = ESP_CONSOLE_REPL_CONFIG_DEFAULT();
       _repl_config.prompt = "esp32m>";
-      logI("setting prompt");
-      #if defined(CONFIG_ESP_CONSOLE_UART_DEFAULT) || defined(CONFIG_ESP_CONSOLE_UART_CUSTOM)
-          _uart_config = ESP_CONSOLE_DEV_UART_CONFIG_DEFAULT();
-      #elif defined(CONFIG_ESP_CONSOLE_USB_CDC)
-          _uart_config = ESP_CONSOLE_DEV_CDC_CONFIG_DEFAULT();
-      #elif defined(CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG)
-          logI("setting USJconfig");
-          _uart_config = ESP_CONSOLE_DEV_USB_SERIAL_JTAG_CONFIG_DEFAULT();
-      #endif
     }
+  
     Console::~Console() {
       if (_repl)
         _repl->del(_repl);
@@ -79,11 +72,14 @@ namespace esp32m {
     void Console::init(Ui *ui) {
       Transport::init(ui);
       #if defined(CONFIG_ESP_CONSOLE_UART_DEFAULT) || defined(CONFIG_ESP_CONSOLE_UART_CUSTOM)
+          esp_console_dev_uart_config_t _uart_config = ESP_CONSOLE_DEV_UART_CONFIG_DEFAULT();
           ESP_ERROR_CHECK(esp_console_new_repl_uart(&_uart_config, &_repl_config, &_repl));
-      #elif defined(CONFIG_ESP_CONSOLE_USB_CDC)
-          ESP_ERROR_CHECK(esp_console_new_repl_usb_cdc(&_uart_config, &_repl_config, &_repl));
-      #elif defined(CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG)
-          ESP_ERROR_CHECK(esp_console_new_repl_usb_serial_jtag(&_uart_config, &_repl_config, &_repl));
+      #elif CONFIG_ESP_CONSOLE_USB_CDC
+          esp_console_dev_usb_cdc_config_t _cdc_config = ESP_CONSOLE_DEV_CDC_CONFIG_DEFAULT();
+          ESP_ERROR_CHECK(esp_console_new_repl_usb_cdc(&_cdc_config, &_repl_config, &_repl));
+      #elif CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+          esp_console_dev_usb_serial_jtag_config_t _usbjtag_config = ESP_CONSOLE_DEV_USB_SERIAL_JTAG_CONFIG_DEFAULT();
+          ESP_ERROR_CHECK(esp_console_new_repl_usb_serial_jtag(&_usbjtag_config, &_repl_config, &_repl));
       #endif
       request_args.name = arg_str1(nullptr, nullptr, "<name>", "request name");
       request_args.data = arg_str0(nullptr, nullptr, "<data>", "JSON data");


### PR DESCRIPTION

Allows use of console on a system with only USB serial JTAG

(ESP_CONSOLE_USB_SERIAL_JTAG=y)
