### PR TITLE
Add menuconfig option to exclude web assets from build

### DIFF
--- a/esp32m/Kconfig
+++ b/esp32m/Kconfig
@@ -1,5 +1,5 @@
 menu "ESP32 Manager configuration"
-    
+
     menu "Logging"
 
         choice ESP32M_LOG_LEVEL
@@ -34,7 +34,7 @@ menu "ESP32 Manager configuration"
             default 6 if ESP32M_LOG_LEVEL_VERBOSE
 
         config ESP32M_LOG_CONSOLE
-            bool "Send log output to UART0 serial console"
+            bool "Send log output to serial console"
             default y
 
         config ESP32M_LOG_UDP
@@ -73,7 +73,7 @@ menu "ESP32 Manager configuration"
             default y
 
         config ESP32M_LOG_HOOK_UART
-            bool "Capture UART0 output"
+            bool "Capture UART output"
             help
                 Attempts to capture everything that is printed to serial console via putc() / printf().
                 This may help to capture additional output that does not use ESP_LOGx macros.
@@ -125,5 +125,29 @@ menu "ESP32 Manager configuration"
         int
         default 0 if ESP32M_FS_ROOT_SPIFFS
         default 1 if ESP32M_FS_ROOT_LITTLEFS
+
+    
+    menu "UI Options"
+
+        config ESP32M_WS_API
+            bool "Include Websockets server API"
+            default y
+            help
+                Runs ESP32M API over websockets
+        
+        config ESP32M_UI
+            bool "Include UI bundle in firmware"
+            depends on ESP32M_WS_API
+            default y
+            help
+                Select this option to include compiled javascript and HTML files in the build,
+                and serve the webapp UI from the device.
+
+                [ To serve the webapp from localhost:9000 (for example during development) 
+                unselect this option, and add the IP of your ESP32 in build/web-ui/webpack.config.js 
+                e.g.{ defines: { esp32m: { backend: { host: '192.168.4.1' } } } } 
+                and run  'yarn start' in build/webui ]
+        
+    endmenu # UI Options
 
 endmenu

--- a/examples/basic/main/CMakeLists.txt
+++ b/examples/basic/main/CMakeLists.txt
@@ -1,6 +1,12 @@
 set(src_dirs ".")
 set(include_dirs ".")
+set(priv_requires "")
+
+if(CONFIG_ESP32M_UI)
+  list(APPEND priv_requires web-ui)
+endif()
+
 idf_component_register(SRC_DIRS ${src_dirs}
                        PRIV_INCLUDE_DIRS ${include_dirs}
-                       PRIV_REQUIRES web-ui)
+                       PRIV_REQUIRES ${priv_requires})
 

--- a/examples/basic/main/main.cpp
+++ b/examples/basic/main/main.cpp
@@ -13,7 +13,9 @@
 #include <esp32m/ui.hpp>
 #include <esp32m/ui/httpd.hpp>
 
-#include <dist/ui.hpp>
+# if CONFIG_ESP32M_UI
+  #include <dist/ui.hpp>
+# endif
 
 // All ESP32 manager code is in under esp32m namespace
 using namespace esp32m;
@@ -33,9 +35,18 @@ extern "C" void app_main() {
   // Retrieve various pieces of info about ESP32 module to be displayed in the
   // UI.
   dev::useEsp32();
-  // Start embedded HTTP server for UI. Just type http://IP_addres_of_your_ESP32
-  // in your web browser to open the UI
-  initUi(new Ui(new ui::Httpd()));
+
+# if CONFIG_ESP32M_WS_API
+  # if CONFIG_ESP32M_UI
+    // Start embedded HTTP server for UI. 
+    initUi(new Ui(new ui::Httpd()));
+  # else
+    // when using localhost to serve UI, only start ws server on device
+    // and run  'yarn start' in ../build/webui to serve web app
+    new Ui(new ui::Httpd());
+  # endif
+# endif
+
   // Add more devices/modules here:
   // dev::useBme280();
   // dev::useBuzzer(GPIO_NUM_15);

--- a/examples/basic/sdkconfig.defaults
+++ b/examples/basic/sdkconfig.defaults
@@ -2,7 +2,7 @@
 # and reduce the size of the bootloader a little, too
 CONFIG_BOOTLOADER_LOG_LEVEL_WARN=y
 CONFIG_LOG_DEFAULT_LEVEL_WARN=y
-ESP32M_LOG_LEVEL_DEBUG=y
+CONFIG_ESP32M_LOG_LEVEL_DEBUG=y
 
 # comment out for default of 160MHz and less power consumption
 CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_240=y
@@ -11,6 +11,9 @@ CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y
 
 # must be enabled if web-ui is used
 CONFIG_HTTPD_WS_SUPPORT=y
+CONFIG_ESP32M_WS_API=y
+CONFIG_ESP32M_UI=y
+
 # modern browsers send too much stuff in headers
 CONFIG_HTTPD_MAX_REQ_HDR_LEN=2048
 # the default of 10 sockets may not be enough for http server to handle incoming http/ws connections

--- a/examples/basic/web-ui/CMakeLists.txt
+++ b/examples/basic/web-ui/CMakeLists.txt
@@ -1,14 +1,23 @@
 set(web_ui_build_dir "${CMAKE_BINARY_DIR}/web-ui")
 
-set(srcs 
+set(srcs "")
+
+set(requires "")
+
+if(CONFIG_ESP32M_UI)
+    list(APPEND srcs 
     "${web_ui_build_dir}/dist/index.html.S"
     "${web_ui_build_dir}/dist/main.js.S"
-)
+    )
+    list(APPEND requires esp32m)
+endif()
 
-idf_component_register(SRCS ${srcs} REQUIRES esp32m)
+# idf_component_register() makes CONFIG_* visible, 
+# so call it with empty list if esp32m not required
+idf_component_register(SRCS ${srcs} REQUIRES ${requires})
 
-set_source_files_properties(${srcs} PROPERTIES GENERATED TRUE)
-
-target_include_directories(${COMPONENT_LIB} PUBLIC ${web_ui_build_dir}) 
-
-add_dependencies(${COMPONENT_LIB} esp32m_web_ui)
+if(CONFIG_ESP32M_UI)
+    set_source_files_properties(${srcs} PROPERTIES GENERATED TRUE)
+    target_include_directories(${COMPONENT_LIB} PUBLIC ${web_ui_build_dir}) 
+    add_dependencies(${COMPONENT_LIB} esp32m_web_ui)   
+endif()

--- a/examples/olimex-eth/main/CMakeLists.txt
+++ b/examples/olimex-eth/main/CMakeLists.txt
@@ -1,6 +1,12 @@
 set(src_dirs ".")
 set(include_dirs ".")
+set(priv_requires "")
+
+if(CONFIG_ESP32M_UI)
+  list(APPEND priv_requires web-ui)
+endif()
+
 idf_component_register(SRC_DIRS ${src_dirs}
                        PRIV_INCLUDE_DIRS ${include_dirs}
-                       PRIV_REQUIRES web-ui)
+                       PRIV_REQUIRES ${priv_requires})
 

--- a/examples/olimex-eth/main/main.cpp
+++ b/examples/olimex-eth/main/main.cpp
@@ -10,7 +10,9 @@
 #include <esp32m/ui.hpp>
 #include <esp32m/ui/httpd.hpp>
 
-#include <dist/ui.hpp>
+#if CONFIG_ESP32M_UI
+  #include <dist/ui.hpp>
+#endif
 
 using namespace esp32m;
 
@@ -23,5 +25,16 @@ extern "C" void app_main()
   net::useWifi();
   net::useOlimexEthernet();
   net::useInterfaces();
+  
+# if CONFIG_ESP32M_WS_API
+# if CONFIG_ESP32M_UI
+  // Start embedded HTTP server for UI. 
   initUi(new Ui(new ui::Httpd()));
+# else
+  // when using localhost to serve UI, only start ws server on device
+  // and run  'yarn start' in ../build/webui to serve web app
+  new Ui(new ui::Httpd());
+# endif
+# endif
+
 }

--- a/examples/olimex-eth/sdkconfig.defaults
+++ b/examples/olimex-eth/sdkconfig.defaults
@@ -1,7 +1,7 @@
 # the following two lines remove unnecessary blob of debug messages sent to UART0 during boot
 CONFIG_BOOTLOADER_LOG_LEVEL_WARN=y
 CONFIG_LOG_DEFAULT_LEVEL_WARN=y
-ESP32M_LOG_LEVEL_DEBUG=y
+CONFIG_ESP32M_LOG_LEVEL_DEBUG=y
 
 # comment out for default of 160MHz and less power consumption
 CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_240=y
@@ -10,6 +10,9 @@ CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y
 
 # must be enabled if web-ui is used
 CONFIG_HTTPD_WS_SUPPORT=y
+CONFIG_ESP32M_WS_API=y
+CONFIG_ESP32M_UI=y
+
 # some browsers send too much stuff in headers
 CONFIG_HTTPD_MAX_REQ_HDR_LEN=2048
 # the default of 10 sockets may not be enough for http server to handle incoming http/ws connections

--- a/examples/olimex-eth/web-ui/CMakeLists.txt
+++ b/examples/olimex-eth/web-ui/CMakeLists.txt
@@ -1,14 +1,19 @@
 set(web_ui_build_dir "${CMAKE_BINARY_DIR}/web-ui")
 
-set(srcs 
-    "${web_ui_build_dir}/dist/index.html.S"
-    "${web_ui_build_dir}/dist/main.js.S"
-)
+
+set(srcs "")
+
+if(CONFIG_ESP32M_UI)
+  list(APPEND srcs 
+  "${web_ui_build_dir}/dist/index.html.S"
+  "${web_ui_build_dir}/dist/main.js.S"
+  )
+endif()
 
 idf_component_register(SRCS ${srcs} REQUIRES esp32m)
 
-set_source_files_properties(${srcs} PROPERTIES GENERATED TRUE)
-
-target_include_directories(${COMPONENT_LIB} PUBLIC ${web_ui_build_dir}) 
-
-add_dependencies(${COMPONENT_LIB} esp32m_web_ui)
+if(CONFIG_ESP32M_UI)
+    set_source_files_properties(${srcs} PROPERTIES GENERATED TRUE)
+    target_include_directories(${COMPONENT_LIB} PUBLIC ${web_ui_build_dir}) 
+    add_dependencies(${COMPONENT_LIB} esp32m_web_ui)
+endif()


### PR DESCRIPTION
I got tired of waiting for my build so wanted to easily switch between embedded and locally hosted webapp.

This PR add a new menu option to menuconfig to allow quick UI configuration changes

CONFIG_ESP32M_UI allows the webapp to be excluded from the build
CONFIG_ESP32M_WS_API allows the ws server to be disabled

[ It turns out that the CONFIG_* variables are not visible in the project CMakeLists.txt,  so "webui" cannot be conditionally included in EXTRA_COMPONENT_DIRS.  Since the call to idf_component_register() is what makes the variables visible,  I put the condition into the webui component CMakeLists.txt itself. ]

I modified the basic and olimex example apps to include these changes, with the default being both enabled.

Maybe worth renaming Kconfig to Kconfig.proj so that  "ESP32 Manager configuration" sits at the top level?