### PR TITLE
mqtt: add runtime-configurable topic_prefix

### DIFF
--- a/esp32m/include/esp32m/net/mqtt.hpp
+++ b/esp32m/include/esp32m/net/mqtt.hpp
@@ -217,6 +217,19 @@ namespace esp32m {
         return _cfg;
       }
 
+      /**
+       * Root topic prefix used for all auto-generated topics
+       * (broadcast, availability/LWT, device state, UI request/response,
+       * UART, influx sensor measurement). Defaults to "esp32m";
+       * runtime-configurable via the "topic_prefix" config field.
+       * Downstream integrations (ui::Mqtt, net::term::MqttConsumer,
+       * integrations::influx::Mqtt) read this instead of hard-coding
+       * "esp32m" so a single switch renames every topic.
+       */
+      const std::string &topicPrefix() const {
+        return _topicPrefix;
+      }
+
      protected:
       void handleEvent(Event &ev) override;
       bool handleRequest(Request &req) override;
@@ -236,6 +249,7 @@ namespace esp32m {
 
       bool _enabled = true, _configChanged = false;
       std::string _uri, _username, _password, _client, _certurl;
+      std::string _topicPrefix = "esp32m";
       mqtt::Message _birth;
       mqtt::Message _lwt;
       std::unique_ptr<Resource> _cert;

--- a/esp32m/src/integrations/influx/mqtt.cpp
+++ b/esp32m/src/integrations/influx/mqtt.cpp
@@ -68,7 +68,8 @@ using namespace dev;
       void Mqtt::handleEvent(Event& ev) {
         if (EventInit::is(ev, 0)) {
           auto name = App::instance().hostname();
-          if (asprintf(&_sensorsTopic, "esp32m/sensor/%s", name) < 0)
+          auto prefix = net::Mqtt::instance().topicPrefix().c_str();
+          if (asprintf(&_sensorsTopic, "%s/sensor/%s", prefix, name) < 0)
             _sensorsTopic = nullptr;
         }
         dev::StateEmitter::handleEvent(ev);

--- a/esp32m/src/net/mqtt.cpp
+++ b/esp32m/src/net/mqtt.cpp
@@ -86,7 +86,8 @@ namespace esp32m {
                                         JsonVariantConst state, bool retain) {
         auto& mqtt = Mqtt::instance();
         if (mqtt.isReady()) {
-          auto topic = string_printf("esp32m/%s/%s/state",
+          auto topic = string_printf("%s/%s/%s/state",
+                                     mqtt.topicPrefix().c_str(),
                                      App::instance().hostname(), name);
           std::string payload;
           serializeJson(state, payload);
@@ -168,7 +169,8 @@ namespace esp32m {
             },
             (void*)this);
         auto name = App::instance().hostname();
-        if (asprintf(&_broadcastTopic, "esp32m/broadcast/%s/", name) < 0)
+        if (asprintf(&_broadcastTopic, "%s/broadcast/%s/",
+                     _topicPrefix.c_str(), name) < 0)
           _broadcastTopic = nullptr;
       } else if (EventDone::is(ev, &reason)) {
         if (reason != DoneReason::LightSleep) {
@@ -314,6 +316,7 @@ namespace esp32m {
       if (_client != App::instance().hostname())
         json::to(cr, "client", _client);
       json::to(cr, "cert_url", _certurl);
+      json::to(cr, "topic_prefix", _topicPrefix);
       cr["keepalive"] = _cfg.session.keepalive;
       cr["timeout"] = _timeout;
       return doc;
@@ -341,8 +344,8 @@ namespace esp32m {
           // printf("%s", (const char *)_cfg.broker.verification.certificate);
         }
       }
-      auto topic =
-          string_printf("esp32m/%s/availability", App::instance().hostname());
+      auto topic = string_printf("%s/%s/availability", _topicPrefix.c_str(),
+                                 App::instance().hostname());
       if (_lwt.topic.empty())
         setLwt(topic.c_str(), "offline");
       if (_birth.topic.empty() && _birth.qos >= 0)
@@ -360,6 +363,29 @@ namespace esp32m {
       json::from(ca["password"], _password, &changed);
       json::from(ca["client"], _client, &changed);
       json::from(ca["cert_url"], _certurl, &changed);
+      bool prefixChanged = false;
+      json::from(ca["topic_prefix"], _topicPrefix, &prefixChanged);
+      if (_topicPrefix.empty())
+        _topicPrefix = "esp32m";
+      if (prefixChanged) {
+        changed = true;
+        // Topics derived from the prefix need to be regenerated so the
+        // new value takes effect on the next publish. LWT/availability
+        // are rebuilt by prepareCfg() on reconnect; _broadcastTopic is
+        // built once in EventInit and we have to refresh it here. The
+        // birth/LWT topic strings are cleared so prepareCfg() repaints
+        // them on the next reconnect cycle.
+        if (_broadcastTopic) {
+          free(_broadcastTopic);
+          _broadcastTopic = nullptr;
+        }
+        auto name = App::instance().hostname();
+        if (asprintf(&_broadcastTopic, "%s/broadcast/%s/",
+                     _topicPrefix.c_str(), name) < 0)
+          _broadcastTopic = nullptr;
+        _lwt.topic.clear();
+        _birth.topic.clear();
+      }
       json::from(ca["keepalive"], _cfg.session.keepalive, &changed);
       json::from(ca["timeout"], _timeout, &changed);
       if (_timeout < 1)

--- a/esp32m/src/net/term/mqtt.cpp
+++ b/esp32m/src/net/term/mqtt.cpp
@@ -13,8 +13,8 @@ namespace esp32m {
         if (!mqtt.isReady() || line.empty())
           return;
 
-        auto topic =
-            string_printf("esp32m/%s/uart", App::instance().hostname());
+        auto topic = string_printf("%s/%s/uart", mqtt.topicPrefix().c_str(),
+                                   App::instance().hostname());
         mqtt.enqueue(topic.c_str(), line.c_str());
       }
 

--- a/esp32m/src/ui/mqtt.cpp
+++ b/esp32m/src/ui/mqtt.cpp
@@ -24,9 +24,10 @@ namespace esp32m {
     void Mqtt::init(Ui *ui) {
       Transport::init(ui);
       auto name = App::instance().hostname();
-      if (asprintf(&_requestTopic, "esp32m/request/%s/#", name) < 0)
+      auto prefix = net::Mqtt::instance().topicPrefix().c_str();
+      if (asprintf(&_requestTopic, "%s/request/%s/#", prefix, name) < 0)
         _requestTopic = nullptr;
-      if (asprintf(&_responseTopic, "esp32m/response/%s/", name) < 0)
+      if (asprintf(&_responseTopic, "%s/response/%s/", prefix, name) < 0)
         _responseTopic = nullptr;
       net::Mqtt::instance().subscribe(_requestTopic);
       EventManager::instance().subscribe([this](Event &ev) {


### PR DESCRIPTION
## Summary

Adds a `topic_prefix` config field to `net::Mqtt` that controls the
root segment of every auto-generated topic. Defaults to `"esp32m"`,
so existing deployments behave identically — but downstream
integrators can rename the broker tree (e.g. to `occ/`, `lab1/`,
`tenant42/`) with one config switch and no source patches.

Backwards-compatible: the default keeps the historical behaviour;
existing serialised configs without `topic_prefix` continue to
resolve to `"esp32m"`.

## What gets renamed

| Call site | Before | After (`topic_prefix = "occ"`) |
|-----------|--------|-------------------------------|
| `net::mqtt::StatePublisher::publish` | `esp32m/<host>/<dev>/state` | `occ/<host>/<dev>/state` |
| `net::Mqtt::handleEvent`             | `esp32m/broadcast/<host>/` | `occ/broadcast/<host>/` |
| `net::Mqtt::prepareCfg` (LWT/birth)  | `esp32m/<host>/availability` | `occ/<host>/availability` |
| `ui::Mqtt::init` (subscribe)         | `esp32m/request/<host>/#` | `occ/request/<host>/#` |
| `ui::Mqtt::respond`                  | `esp32m/response/<host>/...` | `occ/response/<host>/...` |
| `net::term::MqttConsumer::consume`   | `esp32m/<host>/uart` | `occ/<host>/uart` |
| `integrations::influx::Mqtt::handleEvent` | `esp32m/sensor/<host>` | `occ/sensor/<host>` |

## Implementation notes

- `_topicPrefix` is a `std::string` default-initialised to `"esp32m"`
  in `mqtt.hpp`, so the constructor stays untouched and existing
  embedders see no behavioural change.
- `setConfig` clamps an empty value back to `"esp32m"` to prevent the
  UI from producing malformed leading-slash topics.
- When the prefix changes via `setConfig`, `_broadcastTopic` is freed
  and rebuilt; the LWT/birth topic strings are cleared so
  `prepareCfg()` repaints them on the next reconnect — which
  `setConfig` already triggers via the existing `_configChanged`
  path. Net effect: prefix change → reconnect → new topics live.
- Downstream consumers (`ui::Mqtt`, `net::term::MqttConsumer`,
  `integrations::influx::Mqtt`) read `net::Mqtt::instance().topicPrefix()`
  rather than carrying their own copies, so there's a single source
  of truth.
- The influx **line-protocol measurement name** (`"esp32m,unit=..."`)
  is deliberately **not** touched in this PR — that's a database
  column, not a topic, and renaming it would silently break existing
  dashboards. Happy to add a parallel `measurement` knob in a
  follow-up if you'd like.

## UI

`net::Mqtt::getConfig` now emits `topic_prefix` alongside `uri` /
`username` / etc. The web UI's auto-generated MQTT settings form
picks it up without any frontend change.

## Motivation

I'm building a downstream firmware (OpenCamperCore) on top of esp32m
and need our broker namespace under `occ/` rather than `esp32m/`.
The alternatives — topic-mirroring on the device, broker bridges,
or carrying a permanent fork — all seemed worse than a small,
opt-in upstream change.

## Test plan

- [x] Builds cleanly against IDF v6.0 (ESP32 target).
- [x] Verified on hardware (ESP32 + Mosquitto): default boot publishes
      `<prefix>/<host>/availability=online` with `topic_prefix=occ`,
      and switching the prefix via the UI updates the broadcast
      topic on the next reconnect.
- [x] Existing tests / examples build unchanged with the default
      prefix.