### PR TITLE
ota: make HTTPS OTA work against public-CA hosts (cert bundle + drop skip-CN)

### DIFF
--- a/esp32m/src/net/ota.cpp
+++ b/esp32m/src/net/ota.cpp
@@ -393,11 +393,15 @@ namespace esp32m {
       esp_http_client_config_t config = {};
       config.url = url;
       config.timeout_ms = 60 * 1000;
-      config.skip_cert_common_name_check = true;
       // Attach the mbedTLS bundle so HTTPS OTA URLs signed by public
       // CAs (Let's Encrypt etc.) verify without bundling a pinned
       // cert in firmware. Without this, esp_https_ota_begin aborts
       // at the TLS handshake on any standard https:// OTA host.
+      // NOTE: do NOT set skip_cert_common_name_check together with
+      // crt_bundle_attach — that combination causes esp_http_client_open
+      // to abort with ESP_ERR_HTTP_CONNECT before the TLS layer ever
+      // sees the server cert. With a public-CA-backed bundle we want
+      // the CN check on (cert must be issued for the URL's hostname).
       config.crt_bundle_attach = esp_crt_bundle_attach;
       esp_https_ota_config_t ota_config = {};
       ota_config.http_config = &config;

--- a/esp32m/src/net/ota.cpp
+++ b/esp32m/src/net/ota.cpp
@@ -1,3 +1,4 @@
+#include <esp_crt_bundle.h>
 #include <esp_http_client.h>
 #include <esp_https_ota.h>
 #include <esp_ota_ops.h>
@@ -393,6 +394,11 @@ namespace esp32m {
       config.url = url;
       config.timeout_ms = 60 * 1000;
       config.skip_cert_common_name_check = true;
+      // Attach the mbedTLS bundle so HTTPS OTA URLs signed by public
+      // CAs (Let's Encrypt etc.) verify without bundling a pinned
+      // cert in firmware. Without this, esp_https_ota_begin aborts
+      // at the TLS handshake on any standard https:// OTA host.
+      config.crt_bundle_attach = esp_crt_bundle_attach;
       esp_https_ota_config_t ota_config = {};
       ota_config.http_config = &config;
       ota_config.http_client_init_cb = _http_client_init_cb;


### PR DESCRIPTION
## Summary

Two small, related fixes to `net::Ota::perform` so HTTPS OTA actually
completes against any server with a Let's-Encrypt-style public-CA
chain:

1. **Attach the mbedTLS certificate bundle** in the
   `esp_http_client_config_t`. Without this, `esp_https_ota_begin`
   silently aborts at the TLS handshake on any standard `https://`
   OTA host — the device gets the `Request("update")`, emits
   `KeyOtaEnd`, and never reboots.

2. **Drop `skip_cert_common_name_check = true`**. Combined with
   `crt_bundle_attach`, that flag causes `esp_http_client_open` to
   return `ESP_ERR_HTTP_CONNECT` before any TLS handshake bytes hit
   the wire (the underlying `esp_http_client` handle is already torn
   down by the time the error propagates, so even
   `esp_http_client_get_errno` returns garbage). Removing the flag
   lets esp-tls verify the server cert against the bundle normally
   and the install completes.

Both commits are self-contained one-liners (plus the matching
`#include <esp_crt_bundle.h>`).

## How I noticed

I'm carrying a downstream firmware (OpenCamperCore) on top of
ESP32M. With `topic_prefix` (esp32m/core#27) wired up I could
trigger OTA via MQTT (`<prefix>/request/<host>/ota/update`), see
the request accepted, observe `KeyOtaBegin` and `KeyOtaEnd` fire
in the same second on the broker, and the device never reboot.

Adding a one-shot `ota/error` broadcast in my downstream fork
(`{stage, err, name, sock_errno, status, progress, total}`) showed
the failure was `ESP_ERR_HTTP_CONNECT` at stage `begin` — i.e.
`esp_http_client_open` failing, not `_perform` or `_finish`. With
the cert bundle attached AND `skip_cert_common_name_check` removed,
the next attempt completed end-to-end:

```
17:45:41  ota/begin              ← Request("update") accepted
17:46:27  ota/end                ← 46 s download (~1.7 MB image)
17:46:38  availability offline   ← App::restart()
17:46:38  availability online    ← booted into the new image

app/state-get → version: v0.1.0-alpha.6
                (was: v0.1.0-alpha.6-dev-dirty)
```

## Why split into two commits

The cert-bundle change is a pure feature add — without it, no public-
CA OTA works at all. The `skip_cert_common_name_check` removal is a
behaviour change: any user who today relies on a self-signed cert
where the CN doesn't match the URL hostname would notice. I split
them so that part can be reviewed independently. Happy to fold them
together or revisit if maintainers prefer to keep the flag as a
config option.

## Test plan

- [x] Builds cleanly against IDF v6.0 (ESP32 target).
- [x] Verified on hardware (ESP32 + Let's-Encrypt-signed HTTPS host)
      that the full OTA cycle (begin → download → finish → reboot)
      completes; before the patch the same call aborted within the
      same second as `begin`.
- [x] The pre-existing OTA path against self-signed servers using
      explicit `cert_url` config still uses `_certCache.obtain(req)`
      / `_cfg.broker.verification.certificate` and is unaffected.

## Notes

PR sits on top of master and does not depend on
[esp32m/core#27 (topic_prefix)](https://github.com/esp32m/core/pull/27).
Either can land in any order.