### PR TITLE
ota: broadcast ota/error on failure with stage + errno + status

### DIFF
--- a/esp32m/src/net/ota.cpp
+++ b/esp32m/src/net/ota.cpp
@@ -398,7 +398,9 @@ namespace esp32m {
       ota_config.http_client_init_cb = _http_client_init_cb;
       esp_https_ota_handle_t https_ota_handle = NULL;
       esp_err_t err = esp_https_ota_begin(&ota_config, &https_ota_handle);
+      const char *stage = "begin";
       if (ESP_ERROR_CHECK_WITHOUT_ABORT(err) == ESP_OK) {
+        stage = "perform";
         while (1) {
           err = esp_https_ota_perform(https_ota_handle);
           if (err != ESP_ERR_HTTPS_OTA_IN_PROGRESS)
@@ -409,10 +411,39 @@ namespace esp32m {
           delay(1);
           esp_task_wdt_reset();
         }
-        if (err == ESP_OK)
+        if (err == ESP_OK) {
+          stage = "finish";
           err = esp_https_ota_finish(https_ota_handle);
-        else
+        } else
           esp_https_ota_abort(https_ota_handle);
+      }
+      // On failure, broadcast a diagnostic event so an MQTT-attached
+      // operator can identify the failure mode without serial access.
+      // The payload carries which stage of the install pipeline tripped
+      // (begin / perform / finish), the esp_err_t and its symbolic
+      // name, the socket-level errno and last HTTP status the client
+      // saw, plus image-progress counters — enough to distinguish a
+      // TLS handshake abort from a partition write fault from a server
+      // 5xx without further instrumentation.
+      if (err != ESP_OK) {
+        int sock_errno = 0;
+        int status = 0;
+        if (_httpClient) {
+          sock_errno = esp_http_client_get_errno(_httpClient);
+          status = esp_http_client_get_status_code(_httpClient);
+        }
+        logE("OTA failed at stage=%s err=%s (0x%x) sock_errno=%d status=%d",
+             stage, esp_err_to_name(err), err, sock_errno, status);
+        JsonDocument doc;
+        auto obj = doc.to<JsonObject>();
+        obj["stage"] = stage;
+        obj["err"] = (int)err;
+        obj["name"] = esp_err_to_name(err);
+        obj["sock_errno"] = sock_errno;
+        obj["status"] = status;
+        obj["progress"] = _progress;
+        obj["total"] = _total;
+        Broadcast::publish(name(), "error", doc.as<JsonVariantConst>());
       }
       end();
       if (err == ESP_OK) {


### PR DESCRIPTION
## Summary

When `esp_https_ota_begin` / `perform` / `finish` returns non-OK,
publish an `ota/error` broadcast so an MQTT-attached operations
dashboard can identify the failure mode without a serial console.

Today the only failure signal is the `ota/begin → ota/end` pair
firing in the same second (since `end()` runs unconditionally and
`App::restart()` only triggers on success). That tells operators
*that* the install failed but nothing about *why*. This change
fills in the why:

```json
occ/broadcast/<host>/ota/error
  { "stage":      "begin" | "perform" | "finish",
    "err":        <esp_err_t as int>,
    "name":       "ESP_ERR_...",
    "sock_errno": <int, from esp_http_client_get_errno>,
    "status":     <int, last HTTP status>,
    "progress":   <int, bytes received>,
    "total":      <int, Content-Length or 0> }
```

Success path stays silent — no new event. The payload is small
(~120 bytes) and only fires on actual failures, so I left it
unconditional. Happy to gate behind a Kconfig flag if you'd
rather have an explicit opt-in.

## Why I want this

I'm carrying a downstream firmware on top of ESP32M and hit
the exact problem this broadcast solves: HTTPS OTA was silently
failing against a public-CA host, the only on-broker signal was
the begin/end pair, and I couldn't get serial logs in the
deployed scenario. With this event in place, one
`mosquitto_sub … ota/error` showed:

```
{ "stage": "begin",
  "err":   28674,
  "name":  "ESP_ERR_HTTP_CONNECT",
  "sock_errno": 0,
  "status": 0, ... }
```

which immediately pointed at `esp_http_client_open` failing
before any progress — i.e. a TLS-handshake-time abort. From
there it was a quick diff against the ota_watcher's
`esp_http_client_config_t` to spot the misconfigured flag
(addressed in [#28](https://github.com/esp32m/core/pull/28)).

## Test plan

- [x] Builds cleanly against IDF v6.0 (ESP32 target).
- [x] Verified on hardware that:
  - On a failing install (intentionally pointed at a stale URL):
    `ota/error` fires once with the expected stage/errno.
  - On a successful install: no `ota/error`; only the usual
    `ota/begin` / `ota/end` / reboot cycle.

## Notes

Sits on top of master with no dependency on [#27](https://github.com/esp32m/core/pull/27) /
[#28](https://github.com/esp32m/core/pull/28). Any merge order works.