### PR TITLE
bt: fix NimBLE bring-up on ESP-IDF v6

### DIFF
--- a/esp32m/src/bt/ble.cpp
+++ b/esp32m/src/bt/ble.cpp
@@ -206,8 +206,28 @@ namespace esp32m {
     }
 
     bool Ble::init() {
-      ESP_CHECK_RETURN_BOOL(esp_nimble_hci_init());
-      nimble_port_init();
+      // On IDF v6 nimble_port_init() owns the entire bring-up:
+      //   esp_bt_controller_mem_release(CLASSIC_BT)
+      //   esp_bt_controller_init
+      //   esp_bt_controller_enable(BLE)
+      //   esp_nimble_hci_init
+      //   os_mempool_module_init / npl_freertos_funcs_init
+      //   ble_npl_eventq_init(&g_eventq_dflt)
+      // (see bt/host/nimble/nimble/porting/nimble/src/nimble_port.c)
+      // So we must NOT duplicate any of those calls. The old upstream
+      // ble.cpp split bring-up across explicit hci_init + port_init
+      // because earlier IDFs didn't fold them; that path now causes
+      // the second internal controller_init to return
+      // ESP_ERR_INVALID_STATE, nimble_port_init bails before
+      // ble_npl_eventq_init runs, g_eventq_dflt stays uninitialised,
+      // and the host task we spawn next trips a LoadProhibited at
+      // nimble_port.c:420 (ble_npl_eventq_get on a null head).
+      esp_err_t init_err = nimble_port_init();
+      if (init_err != ESP_OK) {
+        ESP_LOGE(name(), "nimble_port_init failed: %s",
+                 esp_err_to_name(init_err));
+        return false;
+      }
       ble_hs_cfg.reset_cb = on_reset;
       ble_hs_cfg.sync_cb = on_sync;
       ble_hs_cfg.store_status_cb = ble_store_util_status_rr;
@@ -224,14 +244,19 @@ namespace esp32m {
       /* Figure out address to use while advertising (no privacy for now) */
       ESP_CHECK_RETURN(ble_hs_id_infer_auto(0, &own_addr_type));
 
-      ble_gap_disc_params disc_params = {
-          .itvl = data["itvl"].as<uint16_t>(),
-          .window = data["window"].as<uint16_t>(),
-          .filter_policy = 0,
-          .limited = data["limited"].as<bool>() ? (uint8_t)1 : (uint8_t)0,
-          .passive = data["active"].as<bool>() ? (uint8_t)0 : (uint8_t)1,
-          .filter_duplicates = 1,
-      };
+      // Zero-init then assign individually: IDF v6's ble_gap_disc_params
+      // added a new field (disable_observer_mode); designated-initializer
+      // form above is rejected by C++ as out-of-order / incomplete. Plain
+      // member assignment is forward-compatible with future field adds.
+      ble_gap_disc_params disc_params = {};
+      disc_params.itvl = data["itvl"].as<uint16_t>();
+      disc_params.window = data["window"].as<uint16_t>();
+      disc_params.filter_policy = 0;
+      disc_params.limited =
+          data["limited"].as<bool>() ? (uint8_t)1 : (uint8_t)0;
+      disc_params.passive =
+          data["active"].as<bool>() ? (uint8_t)0 : (uint8_t)1;
+      disc_params.filter_duplicates = 1;
 
       ESP_CHECK_RETURN(ble_gap_disc(own_addr_type,
                                     data["duration"] | BLE_HS_FOREVER,


### PR DESCRIPTION
## Problem

Building current `master` against ESP-IDF v6 fails (or boots into a `LoadProhibited` crash on first BLE call) for two unrelated reasons in `esp32m/src/bt/ble.cpp`. This PR fixes both as a single minimal change.

### 1. `Ble::init()` — duplicate NimBLE bring-up

IDF v6's `nimble_port_init()` now performs the entire BLE bring-up internally:

- `esp_bt_controller_mem_release(CLASSIC_BT)`
- `esp_bt_controller_init` / `esp_bt_controller_enable(BLE)`
- `esp_nimble_hci_init`
- `os_mempool_module_init` / `npl_freertos_funcs_init`
- `ble_npl_eventq_init(&g_eventq_dflt)`

(See `bt/host/nimble/nimble/porting/nimble/src/nimble_port.c`.)

The current upstream pattern of calling `esp_nimble_hci_init()` explicitly *before* `nimble_port_init()` makes the second internal `hci_init` return `ESP_FAIL` (buffers already allocated). `nimble_port_init` early-returns before `ble_npl_eventq_init` runs, `g_eventq_dflt` stays uninitialised, and the host task we spawn next trips `LoadProhibited` at `nimble_port.c:420` (`ble_npl_eventq_get` on a null head).

**Fix:** call only `nimble_port_init()` and surface its `esp_err_t`. No explicit `esp_nimble_hci_init()`.

### 2. `discStart()` — `ble_gap_disc_params` designated initializer no longer compiles

IDF v6's NimBLE added a new field (`disable_observer_mode`) to `ble_gap_disc_params`. The current C++ designated-initializer form is rejected by current Clang/GCC because the listed members no longer match the struct layout (out-of-order / incomplete in C++).

**Fix:** zero-init then assign members individually. Forward-compatible with future field additions.

## Diff

35 insertions, 10 deletions in one file (`esp32m/src/bt/ble.cpp`). Both hunks are mechanical; the larger size comes from the explanatory comments.

## Test

Tested against ESP-IDF v6.0 + bundled NimBLE on ESP32-S3. BLE discovery works in request-response mode (`Request('scan')`); host task stays alive.