### PR TITLE
net/ota: fix ota::Check signatures for current ArduinoJson + Response API

### DIFF
--- a/esp32m/src/net/ota.cpp
+++ b/esp32m/src/net/ota.cpp
@@ -108,28 +108,15 @@ namespace esp32m {
 
         bool setConfig(RequestContext &ctx) override {
           bool changed = false;
+          auto cfg = ctx.data.as<JsonObjectConst>();
           json::from(cfg["autoupdate"], _autoUpdate, &changed);
           json::from(cfg["autocheck"], _autoCheck, &changed);
           json::from(cfg["checkinterval"], _checkInterval, &changed);
           return changed;
         }
 
-        size_t stateSize() {
-          return 0;
-        }
-        JsonDocument *getState(const JsonVariantConst args) override {
-          auto size = 0;
-          if (_running)
-            size += JSON_OBJECT_SIZE(1);
-          if (_lastCheck)
-            size += JSON_OBJECT_SIZE(1);
-          if (newVersion)
-            size += JSON_OBJECT_SIZE(1) +
-                    JSON_STRING_SIZE(newVersion->version.toString().size());
-          auto errsize = _errors.jsonSize();
-          if (errsize)
-            size += JSON_OBJECT_SIZE(1) + errsize;
-          auto doc = new JsonDocument(); /* size */
+        JsonDocument *getState(RequestContext &ctx) override {
+          auto doc = new JsonDocument();
           auto root = doc->to<JsonObject>();
           if (_running)
             json::to(root, "running", _running);
@@ -137,7 +124,7 @@ namespace esp32m {
             json::to(root, "newver", newVersion->version.toString());
           if (_lastCheck)
             json::to(root, "lastcheck", _lastCheck);
-          if (errsize)
+          if (!_errors.empty())
             _errors.toJson(root);
           return doc;
         }
@@ -243,8 +230,18 @@ namespace esp32m {
           return error(_errors);
         }
         esp_err_t error(ErrorList &list) {
-          if (_manualCheck)
-            Response::respondError(_manualCheck, list);
+          if (_manualCheck) {
+            // Response::respondError(unique_ptr&, ErrorList&) is
+            // commented out in upstream events/response.hpp. Build
+            // the error JSON manually and route via setError to
+            // mark the response as an error.
+            auto errDoc = new JsonDocument();
+            auto root = errDoc->to<JsonObject>();
+            list.toJson(root);
+            _manualCheck->setError(errDoc);
+            _manualCheck->publish();
+            _manualCheck.reset();
+          }
           return ESP_FAIL;
         }
       };


### PR DESCRIPTION
## Problem

The `ota::Check` class (the `CONFIG_ESP32M_NET_OTA_CHECK_FOR_UPDATES` path in `esp32m/src/net/ota.cpp`) was written against older `AppObject` + `Response` + `ErrorList` APIs and no longer compiles against current ArduinoJson and the current upstream `events/response.hpp`.

Three compile failures, all in the same class:

1. **`setConfig`** — referenced an undeclared local `cfg`. Other config-setters in the codebase pull `JsonObjectConst` off `ctx.data`; copied that pattern.

2. **`getState`** — declared as `getState(const JsonVariantConst args)`, which silently hides the `AppObject::getState(RequestContext&)` virtual instead of overriding it (and the build fails with `-Werror`-style flags). Also removed the dead size-hint code that called `ErrorList::jsonSize()` — that method is commented out in upstream `errors.hpp`, and `JsonDocument` no longer needs pre-sized allocators with current ArduinoJson.

3. **`error(ErrorList&)`** — called `Response::respondError(unique_ptr<Response>&, ErrorList&)`, which is commented out in upstream `events/response.hpp`. Rebuilt the error path manually using the same shape as `Response::respond`: construct the JSON, attach via `setError(JsonDocument*)`, `publish()`, `reset()`.

## Why this matters

Without this, `CONFIG_ESP32M_NET_OTA_CHECK_FOR_UPDATES=y` won't build at all on current IDF + ArduinoJson, so the vendor-URL OTA check (which the manifest-fetching loop depends on) is effectively unavailable. Downstream projects end up rolling their own watchers on top of `net::Ota`.

## Test

Clean build against ESP-IDF v6.0 with `CONFIG_ESP32M_NET_OTA_CHECK_FOR_UPDATES=y`. End-to-end manifest fetch + autoupdate exercised against a public-CA-signed manifest URL (this PR pairs naturally with #28 and the related `http::Session` cert-bundle PR for that end-to-end path to actually reach the manifest).