### PR TITLE
net/http: attach mbedTLS cert bundle in http::Session

### DIFF
--- a/esp32m/src/net/http.cpp
+++ b/esp32m/src/net/http.cpp
@@ -1,5 +1,6 @@
 #include "esp32m/net/http.hpp"
 #include <map>
+#include <esp_crt_bundle.h>
 #include "esp32m/defs.hpp"
 
 namespace esp32m {
@@ -155,6 +156,13 @@ namespace esp32m {
         config.event_handler = http_event_handler;
         config.user_data = this;
         config.url = request->url();
+        // Attach the mbedTLS bundle so HTTPS URLs signed by a public
+        // CA (Let's Encrypt etc.) verify without each caller having
+        // to bundle a pinned cert. Without this, every Client::obtain
+        // / Client::describe against an https:// endpoint aborts at
+        // the TLS handshake with ESP_ERR_HTTP_CONNECT — same pattern
+        // we already fixed in net/ota.cpp Ota::perform.
+        config.crt_bundle_attach = esp_crt_bundle_attach;
       }
 
       Resource* Client::describe(ResourceRequest& req) {


### PR DESCRIPTION
## Problem

Mirror of the `Ota::perform` cert-bundle fix in #28, but for the generic `http::Session` used by `Client::obtain` / `Client::describe` (and therefore by `ota::Check::checkForUpdates`, among other callers).

Without `crt_bundle_attach` on the `esp_http_client_config_t`, every `https://` URL signed by a public CA (Let's Encrypt, etc.) aborts at the TLS handshake with `ESP_ERR_HTTP_CONNECT`, because no CA store has been wired in.

## Fix

Attach `esp_crt_bundle_attach` (the mbedTLS bundle) on the client config. Same one-line shape as #28.

```cpp
config.crt_bundle_attach = esp_crt_bundle_attach;
```

## Why this matters

`ota::Check` uses `Client::obtain` to fetch the vendor manifest. With #28 alone, the actual binary download works; with this PR, the manifest fetch that precedes it also works. The pair is needed end-to-end for any public-CA-signed OTA flow.

## Test

Verified against a public-CA-signed manifest URL on ESP-IDF v6.0 — `Client::obtain` returns the manifest body instead of `ESP_ERR_HTTP_CONNECT`.

See also: #28 (the same fix for `Ota::perform`).